### PR TITLE
Migrate to OpenAPI method

### DIFF
--- a/custom_components/foxess_em/__init__.py
+++ b/custom_components/foxess_em/__init__.py
@@ -4,6 +4,7 @@ Custom integration to integrate FoxESS Energy Management with Home Assistant.
 For more details about this integration, please refer to
 https://github.com/nathanmarlor/foxess_em
 """
+
 import asyncio
 import logging
 from datetime import time
@@ -33,13 +34,12 @@ from .const import DAY_BUFFER
 from .const import DOMAIN
 from .const import ECO_END_TIME
 from .const import ECO_START_TIME
+from .const import FOX_API_KEY
 from .const import FOX_CLOUD
 from .const import FOX_MODBUS_HOST
 from .const import FOX_MODBUS_PORT
 from .const import FOX_MODBUS_SERIAL
 from .const import FOX_MODBUS_SLAVE
-from .const import FOX_PASSWORD
-from .const import FOX_USERNAME
 from .const import HOUSE_POWER
 from .const import MIN_SOC
 from .const import PLATFORMS
@@ -76,8 +76,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         entry.data = entry.options
 
     solcast_api_key = entry.data.get(SOLCAST_API_KEY)
-    fox_username = entry.data.get(FOX_USERNAME)
-    fox_password = entry.data.get(FOX_PASSWORD)
+    fox_api_key = entry.data.get(FOX_API_KEY)
 
     eco_start_time = time.fromisoformat(entry.data.get(ECO_START_TIME))
     eco_end_time = time.fromisoformat(entry.data.get(ECO_END_TIME))
@@ -124,7 +123,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     _LOGGER.debug(f"Initialising {connection_type} service")
     if connection_type == FOX_CLOUD:
-        cloud_client = FoxCloudApiClient(session, fox_username, fox_password)
+        cloud_client = FoxCloudApiClient(session, fox_api_key)
         fox_service = FoxCloudService(
             hass, cloud_client, eco_start_time, eco_end_time, user_min_soc
         )
@@ -166,9 +165,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             "charge": charge_service,
         },
         "config": {
-            "connection": Connection.MODBUS
-            if (connection_type in (FOX_MODBUS_TCP, FOX_MODBUS_SERIAL))
-            else Connection.CLOUD
+            "connection": (
+                Connection.MODBUS
+                if (connection_type in (FOX_MODBUS_TCP, FOX_MODBUS_SERIAL))
+                else Connection.CLOUD
+            )
         },
     }
 

--- a/custom_components/foxess_em/__init__.py
+++ b/custom_components/foxess_em/__init__.py
@@ -228,3 +228,17 @@ async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
 async def options_update_listener(hass: HomeAssistant, config_entry: ConfigEntry):
     """Handle options update."""
     await hass.config_entries.async_reload(config_entry.entry_id)
+
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Handle migration from earlier configuration options."""
+    version = config_entry.version
+
+    if version == 1:
+        # Migrate from username/password to API keys.
+        _LOGGER.warning(
+            "FoxESS Energy Management can no longer access foxesscloud.com using a username and password.\r\nPlease reconfigure using API keys."
+        )
+        return False
+
+    return True

--- a/custom_components/foxess_em/const.py
+++ b/custom_components/foxess_em/const.py
@@ -1,4 +1,5 @@
 """Constants for foxess_em."""
+
 # Base component constants
 from enum import Enum
 
@@ -37,8 +38,7 @@ FOX_MODBUS_HOST = "fox_modbus_host"
 FOX_MODBUS_PORT = "fox_modbus_port"
 FOX_MODBUS_SLAVE = "fox_modbus_slave"
 FOX_CLOUD = "Fox Cloud"
-FOX_USERNAME = "fox_username"
-FOX_PASSWORD = "fox_password"
+FOX_API_KEY = "fox_api_key"
 
 # Battery options
 HOUSE_POWER = "house_power"

--- a/custom_components/foxess_em/translations/en.json
+++ b/custom_components/foxess_em/translations/en.json
@@ -17,10 +17,9 @@
       },
       "cloud": {
         "title": "FoxESS - Energy Management: (2/4)",
-        "description": "Please enter your FoxESS Cloud details - https://www.foxesscloud.com",
+        "description": "Please enter your FoxESS Cloud API Key - Go to https://www.foxesscloud.com/user/center and select API Management",
         "data": {
-          "fox_username": "FoxESS Username",
-          "fox_password": "FoxESS Password"
+          "fox_api_key": "FoxESS API Key"
         }
       },
       "tcp": {
@@ -66,7 +65,7 @@
     },
     "error": {
       "solcast_auth": "Error - please check the Solcast API Key",
-      "fox_error": "Error - please check username and password",
+      "fox_error": "Error - please check the FoxESS API Key",
       "fox_select_one": "Error - please choose Modbus or Fox Cloud",
       "time_invalid": "Time format not recognised",
       "modbus_error": "Error - please check connection details"
@@ -93,10 +92,9 @@
       },
       "cloud": {
         "title": "FoxESS - Energy Management: (2/4)",
-        "description": "Please enter your FoxESS Cloud details",
+        "description": "Please enter your FoxESS Cloud API Key - Go to https://www.foxesscloud.com/user/center and select API Management",
         "data": {
-          "fox_username": "FoxESS Username",
-          "fox_password": "FoxESS Password"
+          "fox_api_key": "FoxESS API Key"
         }
       },
       "tcp": {
@@ -142,7 +140,7 @@
     },
     "error": {
       "solcast_auth": "Error - please check the Solcast API Key",
-      "fox_error": "Error - please check username and password",
+      "fox_error": "Error - please check the FoxESS API Key",
       "fox_select_one": "Error - please choose Modbus or Fox Cloud",
       "time_invalid": "Time format not recognised",
       "modbus_error": "Error - please check connection details"


### PR DESCRIPTION
This is based on the foxess-ha work on converting to OpenAPI which is based on https://www.foxesscloud.com/public/i18n/en/OpenApiDocument.html.

The configuration MAJOR version changes to 2, so it should report errors if you upgrade without reconfiguring. I'm not sure if there's much more you can do but would be happy to make further changes.