### PR TITLE
Fix config upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,13 @@ Choose from one of the following options:
 
 <b>FoxESS Cloud</b>
 
-- **Username**: Username from FoxESS Cloud
-- **Password**: Password from FoxESS Cloud
+- **API Key**: API Key from FoxESS Cloud. To find this, go to https://www.foxesscloud.com/, select
+  the User icon in the top right corner and select User Profile, then select API Management and
+  generate an API key if you do not already have one.
+
+Do not generate a new key if you have already generated one for something else (e.g.
+[foxess-ha](https://github.com/macxq/foxess-ha)), as this will invalidate the previous key and you
+will have to reconfigure your other uses.
 
 ![FOX](images/config-step-2-fox.png)
 

--- a/custom_components/foxess_em/fox/fox_cloud_api.py
+++ b/custom_components/foxess_em/fox/fox_cloud_api.py
@@ -91,9 +91,7 @@ class FoxCloudApiClient:
             if status == _FOX_OK:
                 return result["result"]
             elif status == _FOX_INVALID_TOKEN:
-                _LOGGER.debug("Fox Cloud token has expired - refreshing...")
-                await self._refresh_token()
-                return await self._post_data(url, params)
+                raise NoDataError(f"Fox Cloud API Key is not valid - Error: {status}")
             elif status == _FOX_TIMEOUT and self._fox_retries < _FOX_RETRIES:
                 self._fox_retries += 1
                 sleep_time = self._fox_retries * _FOX_RETRY_DELAY

--- a/custom_components/foxess_em/translations/en.json
+++ b/custom_components/foxess_em/translations/en.json
@@ -22,6 +22,13 @@
           "fox_api_key": "FoxESS API Key"
         }
       },
+      "reauth_fox_api_key": {
+        "title": "FoxESS - Energy Management",
+        "description": "Please enter your FoxESS Cloud API Key - Go to https://www.foxesscloud.com/user/center and select API Management",
+        "data": {
+          "fox_api_key": "FoxESS API Key"
+        }
+      },
       "tcp": {
         "title": "FoxESS - Energy Management: (2/4)",
         "description": "Please enter your Modbus TCP details",
@@ -71,7 +78,8 @@
       "modbus_error": "Error - please check connection details"
     },
     "abort": {
-      "single_instance_allowed": "Only a single instance is allowed."
+      "single_instance_allowed": "Only a single instance is allowed.",
+      "reauth_successful": "FoxESS API Key updated successfully."
     }
   },
   "options": {


### PR DESCRIPTION
The previous update changed the major version of the config from 1 to 2 and then made it so thatmigration always failed. The intention was that reconfiguration would somehow automatically fix this, but sadly that didn't work. With this change the config is automatically migrated to 2. Just to make this more complicated, the HA API for this is changing in 2024.3, so there are two code paths to handle the version change.

The API key is then checked during initialization and if it doesn't work, ConfigEntryAuthFailed is raised. This shows up as a repair in settings which prompts the user to enter an API key.

Also updates the documentation to remove references to username/password and fixes a bug where it tried to refresh the old-style authentication token.