### PR TITLE
Change python import sorter to isort and fix hassfest errors

### DIFF
--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -2,4 +2,3 @@ pip==23.1.2
 pre-commit==3.3.2
 black==23.3.0
 flake8==6.0.0
-reorder-python-imports==3.9.0

--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,3 +1,2 @@
 pip==23.1.2
 pre-commit==3.3.2
-flake8==6.0.0

--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,4 +1,3 @@
 pip==23.1.2
 pre-commit==3.3.2
-black==23.3.0
 flake8==6.0.0

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,7 @@ on:
     - cron: "0 0 * * *"
 
 env:
-  DEFAULT_PYTHON: 3.9
+  DEFAULT_PYTHON: 3.12
 
 jobs:
   pre-commit:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install Python modules
         run: |
-          pip install --constraint=.github/workflows/constraints.txt pre-commit black flake8 reorder-python-imports
+          pip install --constraint=.github/workflows/constraints.txt pre-commit black flake8
 
       - name: Run pre-commit on all files
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install Python modules
         run: |
-          pip install --constraint=.github/workflows/constraints.txt pre-commit black flake8
+          pip install --constraint=.github/workflows/constraints.txt pre-commit flake8
 
       - name: Run pre-commit on all files
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,14 +6,6 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: local
-    hooks:
-      - id: flake8
-        name: flake8
-        entry: flake8
-        language: system
-        types: [python]
-        require_serial: true
   # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.2.0
@@ -29,6 +21,10 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.2.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,18 +8,22 @@ repos:
       - id: trailing-whitespace
   - repo: local
     hooks:
-      - id: black
-        name: black
-        entry: black
-        language: system
-        types: [python]
-        require_serial: true
       - id: flake8
         name: flake8
         entry: flake8
         language: system
         types: [python]
         require_serial: true
+  # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 24.2.0
+    hooks:
+      - id: black
+        # It is recommended to specify the latest version of Python
+        # supported by your project here, or alternatively use
+        # pre-commit's default_language_version, see
+        # https://pre-commit.com/#top_level-default_language_version
+        language_version: python3.12
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,12 +20,11 @@ repos:
         language: system
         types: [python]
         require_serial: true
-      - id: reorder-python-imports
-        name: Reorder python imports
-        entry: reorder-python-imports
-        language: system
-        types: [python]
-        args: [--application-directories=custom_components]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        name: isort (python)
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.2.1
     hooks:

--- a/custom_components/foxess_em/__init__.py
+++ b/custom_components/foxess_em/__init__.py
@@ -6,51 +6,53 @@ https://github.com/nathanmarlor/foxess_em
 """
 
 import asyncio
-import logging
 from datetime import time
+import logging
+
+from homeassistant.config_entries import ConfigEntry, ConfigEntryAuthFailed
+from homeassistant.const import (
+    MAJOR_VERSION as HA_MAJOR_VERSION,
+    MINOR_VERSION as HA_MINOR_VERSION,
+)
+from homeassistant.core import Config, HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from custom_components.foxess_em.battery.schedule import Schedule
 from custom_components.foxess_em.fox.fox_modbus import FoxModbus
 from custom_components.foxess_em.fox.fox_modbus_service import FoxModbuservice
 from custom_components.foxess_em.util.peak_period_util import PeakPeriodUtils
-from homeassistant.config_entries import ConfigEntry, ConfigEntryAuthFailed
-from homeassistant.core import Config
-from homeassistant.core import HomeAssistant
-from homeassistant.const import (
-    MAJOR_VERSION as HA_MAJOR_VERSION,
-    MINOR_VERSION as HA_MINOR_VERSION,
-)
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .average.average_controller import AverageController
 from .battery.battery_controller import BatteryController
 from .charge.charge_service import ChargeService
 from .config_flow import BatteryManagerFlowHandler
-from .const import AUX_POWER
-from .const import BATTERY_CAPACITY
-from .const import BATTERY_SOC
-from .const import BATTERY_VOLTS
-from .const import CHARGE_AMPS
-from .const import Connection
-from .const import CONNECTION_TYPE
-from .const import DAWN_BUFFER
-from .const import DAY_BUFFER
-from .const import DOMAIN
-from .const import ECO_END_TIME
-from .const import ECO_START_TIME
-from .const import FOX_API_KEY
-from .const import FOX_CLOUD
-from .const import FOX_MODBUS_HOST
-from .const import FOX_MODBUS_PORT
-from .const import FOX_MODBUS_SERIAL
-from .const import FOX_MODBUS_SLAVE
-from .const import FOX_MODBUS_TCP
-from .const import HOUSE_POWER
-from .const import MIN_SOC
-from .const import PLATFORMS
-from .const import SOLCAST_API_KEY
-from .const import SOLCAST_URL
-from .const import STARTUP_MESSAGE
+from .const import (
+    AUX_POWER,
+    BATTERY_CAPACITY,
+    BATTERY_SOC,
+    BATTERY_VOLTS,
+    CHARGE_AMPS,
+    CONNECTION_TYPE,
+    DAWN_BUFFER,
+    DAY_BUFFER,
+    DOMAIN,
+    ECO_END_TIME,
+    ECO_START_TIME,
+    FOX_API_KEY,
+    FOX_CLOUD,
+    FOX_MODBUS_HOST,
+    FOX_MODBUS_PORT,
+    FOX_MODBUS_SERIAL,
+    FOX_MODBUS_SLAVE,
+    FOX_MODBUS_TCP,
+    HOUSE_POWER,
+    MIN_SOC,
+    PLATFORMS,
+    SOLCAST_API_KEY,
+    SOLCAST_URL,
+    STARTUP_MESSAGE,
+    Connection,
+)
 from .forecast.forecast_controller import ForecastController
 from .forecast.solcast_api import SolcastApiClient
 from .fox.fox_cloud_api import FoxCloudApiClient

--- a/custom_components/foxess_em/__init__.py
+++ b/custom_components/foxess_em/__init__.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     MINOR_VERSION as HA_MINOR_VERSION,
 )
 from homeassistant.core import Config, HomeAssistant
+from homeassistant.helpers import config_validation
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from custom_components.foxess_em.battery.schedule import Schedule
@@ -59,6 +60,8 @@ from .fox.fox_cloud_api import FoxCloudApiClient
 from .fox.fox_cloud_service import FoxCloudService
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
+
+CONFIG_SCHEMA = config_validation.config_entry_only_config_schema(DOMAIN)
 
 
 async def async_setup(hass: HomeAssistant, config: Config):

--- a/custom_components/foxess_em/average/average_controller.py
+++ b/custom_components/foxess_em/average/average_controller.py
@@ -1,19 +1,18 @@
 """Average controller"""
-import logging
-from datetime import datetime
-from datetime import time
-from datetime import timedelta
 
-from custom_components.foxess_em.common.hass_load_controller import HassLoadController
+from datetime import datetime, time, timedelta
+import logging
+
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.event import async_track_utc_time_change
 from pandas import DataFrame
 
+from custom_components.foxess_em.common.hass_load_controller import HassLoadController
+
 from ..average.average_model import AverageModel
 from ..common.callback_controller import CallbackController
 from ..common.unload_controller import UnloadController
-from .tracked_sensor import HistorySensor
-from .tracked_sensor import TrackedSensor
+from .tracked_sensor import HistorySensor, TrackedSensor
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/foxess_em/average/average_model.py
+++ b/custom_components/foxess_em/average/average_model.py
@@ -1,17 +1,15 @@
 """Average model"""
-import logging
-from datetime import datetime
-from datetime import time
 
-import pandas as pd
+from datetime import datetime, time
+import logging
+
 from dateutil import tz
-from homeassistant.components.recorder import get_instance
-from homeassistant.components.recorder import history
+from homeassistant.components.recorder import get_instance, history
 from homeassistant.core import HomeAssistant
+import pandas as pd
 
 from ..util.exceptions import NoDataError
-from .tracked_sensor import HistorySensor
-from .tracked_sensor import TrackedSensor
+from .tracked_sensor import HistorySensor, TrackedSensor
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/foxess_em/average/average_sensor.py
+++ b/custom_components/foxess_em/average/average_sensor.py
@@ -1,4 +1,5 @@
 """Average sensor"""
+
 import logging
 
 from homeassistant.components.sensor import SensorDeviceClass

--- a/custom_components/foxess_em/average/tracked_sensor.py
+++ b/custom_components/foxess_em/average/tracked_sensor.py
@@ -1,4 +1,5 @@
 """Tracked sensor data model"""
+
 from dataclasses import dataclass
 from datetime import timedelta
 

--- a/custom_components/foxess_em/battery/battery_controller.py
+++ b/custom_components/foxess_em/battery/battery_controller.py
@@ -1,14 +1,15 @@
 """Battery controller"""
+
+from datetime import datetime, time
 import logging
-from datetime import datetime
-from datetime import time
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.event import async_track_state_change
 
 from custom_components.foxess_em.battery.battery_util import BatteryUtils
 from custom_components.foxess_em.battery.schedule import Schedule
 from custom_components.foxess_em.common.hass_load_controller import HassLoadController
 from custom_components.foxess_em.util.peak_period_util import PeakPeriodUtils
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.event import async_track_state_change
 
 from ..average.average_controller import AverageController
 from ..common.callback_controller import CallbackController

--- a/custom_components/foxess_em/battery/battery_model.py
+++ b/custom_components/foxess_em/battery/battery_model.py
@@ -1,15 +1,15 @@
 """Battery model"""
+
+from datetime import datetime, time, timedelta
 import json
 import logging
-from datetime import datetime
-from datetime import time
-from datetime import timedelta
 
+from homeassistant.core import HomeAssistant
 import pandas as pd
+
 from custom_components.foxess_em.battery.battery_util import BatteryUtils
 from custom_components.foxess_em.battery.schedule import Schedule
 from custom_components.foxess_em.util.peak_period_util import PeakPeriodUtils
-from homeassistant.core import HomeAssistant
 
 from ..util.exceptions import NoDataError
 

--- a/custom_components/foxess_em/battery/battery_number.py
+++ b/custom_components/foxess_em/battery/battery_number.py
@@ -1,9 +1,9 @@
 """Battery switch"""
+
 import logging
 
 from custom_components.foxess_em.common.number import Number
 from custom_components.foxess_em.common.number_desc import NumberDescription
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/foxess_em/battery/battery_sensor.py
+++ b/custom_components/foxess_em/battery/battery_sensor.py
@@ -1,4 +1,5 @@
 """Battery sensor"""
+
 import logging
 
 from homeassistant.components.sensor import SensorDeviceClass

--- a/custom_components/foxess_em/battery/battery_switch.py
+++ b/custom_components/foxess_em/battery/battery_switch.py
@@ -1,9 +1,9 @@
 """Battery switch"""
+
 import logging
 
 from ..common.switch import Switch
 from ..common.switch_desc import SwitchDescription
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/foxess_em/battery/battery_util.py
+++ b/custom_components/foxess_em/battery/battery_util.py
@@ -1,4 +1,5 @@
 """Battery controller"""
+
 import logging
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/foxess_em/battery/schedule.py
+++ b/custom_components/foxess_em/battery/schedule.py
@@ -1,13 +1,14 @@
 """Battery controller"""
+
+from datetime import datetime, timedelta
 import logging
-from datetime import datetime
-from datetime import timedelta
 from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.event import async_track_utc_time_change
 
 from custom_components.foxess_em.common.hass_load_controller import HassLoadController
 from custom_components.foxess_em.common.unload_controller import UnloadController
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.event import async_track_utc_time_change
 
 _LOGGER = logging.getLogger(__name__)
 _SCHEDULE = "sensor.foxess_em_schedule"

--- a/custom_components/foxess_em/calendar.py
+++ b/custom_components/foxess_em/calendar.py
@@ -1,13 +1,14 @@
 """Calendar entries"""
-import logging
-from datetime import datetime
 
-from custom_components.foxess_em.const import DOMAIN
-from homeassistant.components.calendar import CalendarEntity
-from homeassistant.components.calendar import CalendarEvent
+from datetime import datetime
+import logging
+
+from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from custom_components.foxess_em.const import DOMAIN
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 

--- a/custom_components/foxess_em/charge/charge_service.py
+++ b/custom_components/foxess_em/charge/charge_service.py
@@ -1,16 +1,17 @@
 """Charge service"""
+
 import asyncio
+from datetime import date, datetime, time, timedelta
 import logging
-from datetime import date
-from datetime import datetime
-from datetime import time
-from datetime import timedelta
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.event import (
+    async_track_state_change,
+    async_track_utc_time_change,
+)
 
 from custom_components.foxess_em.fox.fox_service import FoxService
 from custom_components.foxess_em.util.peak_period_util import PeakPeriodUtils
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.event import async_track_state_change
-from homeassistant.helpers.event import async_track_utc_time_change
 
 from ..battery.battery_controller import BatteryController
 from ..common.unload_controller import UnloadController

--- a/custom_components/foxess_em/charge/charge_switch.py
+++ b/custom_components/foxess_em/charge/charge_switch.py
@@ -1,11 +1,11 @@
 """Battery switch"""
+
 import logging
 
 from custom_components.foxess_em.const import Connection
 
 from ..common.switch import Switch
 from ..common.switch_desc import SwitchDescription
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/foxess_em/common/callback_controller.py
+++ b/custom_components/foxess_em/common/callback_controller.py
@@ -1,4 +1,5 @@
 """Callback controller"""
+
 import logging
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/foxess_em/common/hass_load_controller.py
+++ b/custom_components/foxess_em/common/hass_load_controller.py
@@ -1,11 +1,10 @@
 """Callback controller"""
+
 import asyncio
 import logging
 from typing import Callable
 
-from homeassistant.core import CoreState
-from homeassistant.core import EVENT_HOMEASSISTANT_STARTED
-from homeassistant.core import HomeAssistant
+from homeassistant.core import EVENT_HOMEASSISTANT_STARTED, CoreState, HomeAssistant
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/foxess_em/common/number.py
+++ b/custom_components/foxess_em/common/number.py
@@ -1,17 +1,15 @@
 """Home Assistant switch"""
+
 import logging
 
-from custom_components.foxess_em.common.number_desc import NumberDescription
 from homeassistant.components.number import NumberEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_IDENTIFIERS
-from homeassistant.const import ATTR_NAME
+from homeassistant.const import ATTR_IDENTIFIERS, ATTR_NAME
 from homeassistant.helpers.device_registry import DeviceEntryType
 
-from ..const import ATTR_ENTRY_TYPE
-from ..const import DEFAULT_NAME
-from ..const import DOMAIN
-from ..const import NUMBER
+from custom_components.foxess_em.common.number_desc import NumberDescription
+
+from ..const import ATTR_ENTRY_TYPE, DEFAULT_NAME, DOMAIN, NUMBER
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/foxess_em/common/number_desc.py
+++ b/custom_components/foxess_em/common/number_desc.py
@@ -1,4 +1,5 @@
 """Custom sensor with optional properties"""
+
 from dataclasses import dataclass
 
 from homeassistant.components.number import NumberEntityDescription

--- a/custom_components/foxess_em/common/sensor.py
+++ b/custom_components/foxess_em/common/sensor.py
@@ -1,20 +1,22 @@
 """Sensor"""
+
 import logging
 from typing import Any
 
 from attr import dataclass
-from custom_components.foxess_em.common.callback_controller import CallbackController
-from homeassistant.components.sensor import ExtraStoredData
-from homeassistant.components.sensor import RestoreEntity
-from homeassistant.components.sensor import SensorDeviceClass
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import (
+    ExtraStoredData,
+    RestoreEntity,
+    SensorDeviceClass,
+    SensorEntity,
+)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_IDENTIFIERS
-from homeassistant.const import ATTR_NAME
+from homeassistant.const import ATTR_IDENTIFIERS, ATTR_NAME
 from homeassistant.helpers.device_registry import DeviceEntryType
 
-from ..const import ATTR_ENTRY_TYPE
-from ..const import DOMAIN
+from custom_components.foxess_em.common.callback_controller import CallbackController
+
+from ..const import ATTR_ENTRY_TYPE, DOMAIN
 from .sensor_desc import SensorDescription
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/foxess_em/common/sensor_desc.py
+++ b/custom_components/foxess_em/common/sensor_desc.py
@@ -1,6 +1,6 @@
 """Custom sensor with optional properties"""
-from dataclasses import dataclass
-from dataclasses import field
+
+from dataclasses import dataclass, field
 
 from homeassistant.components.sensor import SensorEntityDescription
 

--- a/custom_components/foxess_em/common/switch.py
+++ b/custom_components/foxess_em/common/switch.py
@@ -1,18 +1,15 @@
 """Home Assistant switch"""
+
 import logging
 
 from homeassistant.components.sensor import RestoreEntity
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_IDENTIFIERS
-from homeassistant.const import ATTR_NAME
+from homeassistant.const import ATTR_IDENTIFIERS, ATTR_NAME
 from homeassistant.helpers.device_registry import DeviceEntryType
 
 from ..common.switch_desc import SwitchDescription
-from ..const import ATTR_ENTRY_TYPE
-from ..const import DEFAULT_NAME
-from ..const import DOMAIN
-from ..const import SWITCH
+from ..const import ATTR_ENTRY_TYPE, DEFAULT_NAME, DOMAIN, SWITCH
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/foxess_em/common/switch_desc.py
+++ b/custom_components/foxess_em/common/switch_desc.py
@@ -1,8 +1,10 @@
 """Custom sensor with optional properties"""
+
 from dataclasses import dataclass
 
-from custom_components.foxess_em.const import Connection
 from homeassistant.components.switch import SwitchEntityDescription
+
+from custom_components.foxess_em.const import Connection
 
 
 @dataclass

--- a/custom_components/foxess_em/common/unload_controller.py
+++ b/custom_components/foxess_em/common/unload_controller.py
@@ -1,4 +1,5 @@
 """Unload controller"""
+
 import logging
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/foxess_em/config_flow.py
+++ b/custom_components/foxess_em/config_flow.py
@@ -4,39 +4,39 @@ import datetime
 import logging
 from typing import Any
 
-import voluptuous as vol
-from custom_components.foxess_em.fox.fox_modbus import FoxModbus
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers import selector
+from homeassistant.helpers import config_validation as cv, selector
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.selector import selector as sel
 from pymodbus.exceptions import ModbusException
+import voluptuous as vol
 
-from ..foxess_em.const import DAWN_BUFFER
-from ..foxess_em.const import DAY_BUFFER
-from ..foxess_em.const import MIN_SOC
-from .const import AUX_POWER
-from .const import BATTERY_CAPACITY
-from .const import BATTERY_SOC
-from .const import BATTERY_VOLTS
-from .const import CHARGE_AMPS
-from .const import CONNECTION_TYPE
-from .const import DOMAIN
-from .const import ECO_END_TIME
-from .const import ECO_START_TIME
-from .const import FOX_CLOUD
-from .const import FOX_MODBUS_HOST
-from .const import FOX_MODBUS_PORT
-from .const import FOX_MODBUS_SERIAL
-from .const import FOX_MODBUS_SLAVE
-from .const import FOX_MODBUS_TCP
-from .const import FOX_API_KEY
-from .const import HOUSE_POWER
-from .const import SOLCAST_API_KEY
-from .const import SOLCAST_URL
+from custom_components.foxess_em.fox.fox_modbus import FoxModbus
+
+from ..foxess_em.const import DAWN_BUFFER, DAY_BUFFER, MIN_SOC
+from .const import (
+    AUX_POWER,
+    BATTERY_CAPACITY,
+    BATTERY_SOC,
+    BATTERY_VOLTS,
+    CHARGE_AMPS,
+    CONNECTION_TYPE,
+    DOMAIN,
+    ECO_END_TIME,
+    ECO_START_TIME,
+    FOX_API_KEY,
+    FOX_CLOUD,
+    FOX_MODBUS_HOST,
+    FOX_MODBUS_PORT,
+    FOX_MODBUS_SERIAL,
+    FOX_MODBUS_SLAVE,
+    FOX_MODBUS_TCP,
+    HOUSE_POWER,
+    SOLCAST_API_KEY,
+    SOLCAST_URL,
+)
 from .forecast.solcast_api import SolcastApiClient
 from .fox.fox_cloud_api import FoxCloudApiClient
 from .fox.fox_cloud_service import FoxCloudService

--- a/custom_components/foxess_em/const.py
+++ b/custom_components/foxess_em/const.py
@@ -3,7 +3,6 @@
 # Base component constants
 from enum import Enum
 
-
 NAME = "foxess_em"
 DOMAIN = "foxess_em"
 DOMAIN_DATA = f"{DOMAIN}_data"

--- a/custom_components/foxess_em/energy.py
+++ b/custom_components/foxess_em/energy.py
@@ -1,4 +1,5 @@
 """Energy platform."""
+
 from __future__ import annotations
 
 import logging

--- a/custom_components/foxess_em/forecast/forecast_controller.py
+++ b/custom_components/foxess_em/forecast/forecast_controller.py
@@ -1,14 +1,14 @@
 """Forecast controller"""
-import logging
-from datetime import datetime
-from datetime import time
-from datetime import timedelta
 
-from custom_components.foxess_em.common.hass_load_controller import HassLoadController
-from custom_components.foxess_em.const import FORECAST
+from datetime import datetime, time, timedelta
+import logging
+
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.event import async_track_utc_time_change
 from pandas import DataFrame
+
+from custom_components.foxess_em.common.hass_load_controller import HassLoadController
+from custom_components.foxess_em.const import FORECAST
 
 from ..common.callback_controller import CallbackController
 from ..common.unload_controller import UnloadController

--- a/custom_components/foxess_em/forecast/forecast_model.py
+++ b/custom_components/foxess_em/forecast/forecast_model.py
@@ -1,7 +1,7 @@
 """Forecast model"""
+
+from datetime import datetime, timedelta
 import logging
-from datetime import datetime
-from datetime import timedelta
 
 import pandas as pd
 

--- a/custom_components/foxess_em/forecast/forecast_sensor.py
+++ b/custom_components/foxess_em/forecast/forecast_sensor.py
@@ -1,4 +1,5 @@
 """Solcast sensor"""
+
 import logging
 
 from homeassistant.components.sensor import SensorDeviceClass

--- a/custom_components/foxess_em/forecast/solcast_api.py
+++ b/custom_components/foxess_em/forecast/solcast_api.py
@@ -1,6 +1,7 @@
 """Sample API Client."""
-import logging
+
 from datetime import timedelta
+import logging
 from typing import Any
 
 import aiohttp

--- a/custom_components/foxess_em/fox/fox_cloud_service.py
+++ b/custom_components/foxess_em/fox/fox_cloud_service.py
@@ -1,15 +1,13 @@
 """Fox controller"""
 
+from datetime import datetime, time
 import logging
-from datetime import datetime
-from datetime import time
 
 from homeassistant.core import HomeAssistant
 
 from ..util.exceptions import NoDataError
 from .fox_cloud_api import FoxCloudApiClient
 from .fox_service import FoxService
-
 
 _SET_TIMES = "/op/v0/device/battery/forceChargeTime/set"
 _DEVICE = "/op/v0/device/list"

--- a/custom_components/foxess_em/fox/fox_modbus.py
+++ b/custom_components/foxess_em/fox/fox_modbus.py
@@ -2,13 +2,14 @@ import asyncio
 import logging
 from typing import Any
 
-from custom_components.foxess_em.const import CONNECTION_TYPE
-from custom_components.foxess_em.const import FOX_MODBUS_SERIAL
-from custom_components.foxess_em.const import FOX_MODBUS_TCP
-from pymodbus.client import ModbusSerialClient
-from pymodbus.client import ModbusTcpClient
-from pymodbus.exceptions import ModbusException
-from pymodbus.exceptions import ModbusIOException
+from pymodbus.client import ModbusSerialClient, ModbusTcpClient
+from pymodbus.exceptions import ModbusException, ModbusIOException
+
+from custom_components.foxess_em.const import (
+    CONNECTION_TYPE,
+    FOX_MODBUS_SERIAL,
+    FOX_MODBUS_TCP,
+)
 
 _LOGGER = logging.getLogger(__name__)
 _WRITE_ATTEMPTS = 5

--- a/custom_components/foxess_em/fox/fox_modbus_service.py
+++ b/custom_components/foxess_em/fox/fox_modbus_service.py
@@ -1,7 +1,7 @@
 """Fox controller"""
+
+from datetime import datetime, time
 import logging
-from datetime import datetime
-from datetime import time
 
 from homeassistant.core import HomeAssistant
 

--- a/custom_components/foxess_em/fox/fox_service.py
+++ b/custom_components/foxess_em/fox/fox_service.py
@@ -1,4 +1,5 @@
 """Fox controller"""
+
 import logging
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/foxess_em/number.py
+++ b/custom_components/foxess_em/number.py
@@ -1,4 +1,5 @@
 """Home Assistant switch"""
+
 from homeassistant.config_entries import ConfigEntry
 
 from .battery import battery_number

--- a/custom_components/foxess_em/sensor.py
+++ b/custom_components/foxess_em/sensor.py
@@ -1,4 +1,5 @@
 """Sensor platform for foxess_em."""
+
 import logging
 
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/foxess_em/switch.py
+++ b/custom_components/foxess_em/switch.py
@@ -1,10 +1,10 @@
 """Home Assistant switch"""
+
 from homeassistant.config_entries import ConfigEntry
 
 from .battery import battery_switch
 from .charge import charge_switch
-from .const import Connection
-from .const import DOMAIN
+from .const import DOMAIN, Connection
 
 
 async def async_setup_entry(hass, entry: ConfigEntry, async_add_devices):

--- a/custom_components/foxess_em/translations/en.json
+++ b/custom_components/foxess_em/translations/en.json
@@ -156,5 +156,15 @@
     "abort": {
       "single_instance_allowed": "Only a single instance is allowed."
     }
+  },
+  "services": {
+    "fox_start_force_charge": {
+      "name": "Start force charge",
+      "description": "Starts force charge now until midnight."
+    },
+    "fox_stop_force_charge": {
+      "name": "Stop force charge",
+      "description": "Stops force charge."
+    }
   }
 }

--- a/custom_components/foxess_em/util/peak_period_util.py
+++ b/custom_components/foxess_em/util/peak_period_util.py
@@ -1,8 +1,6 @@
 """"Datetime utilities"""
-from datetime import date
-from datetime import datetime
-from datetime import time
-from datetime import timedelta
+
+from datetime import date, datetime, time, timedelta
 
 
 class PeakPeriodUtils:


### PR DESCRIPTION
Since reorder-python-imports and black conflict in how they format, the pre-commits were always failing. isort is designed to be compatible with black so it should not have these problems in the future.

Having changed the formatters, this then reformats all files so that the formatter pre-commits all pass.

Fixes #359 