### PR TITLE
Fix unused argument warnings

### DIFF
--- a/custom_components/foxess_em/average/average_controller.py
+++ b/custom_components/foxess_em/average/average_controller.py
@@ -6,6 +6,7 @@ import logging
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.event import async_track_utc_time_change
 from pandas import DataFrame
+from typing import Any
 
 from custom_components.foxess_em.common.hass_load_controller import HassLoadController
 
@@ -62,7 +63,7 @@ class AverageController(UnloadController, CallbackController, HassLoadController
         """Model status"""
         return self._model.ready()
 
-    async def async_refresh(self, *args) -> None:  # pylint: disable=unused-argument
+    async def async_refresh(self, *_: Any) -> None:
         """Refresh data"""
         _LOGGER.debug("Refreshing averages model")
 

--- a/custom_components/foxess_em/battery/battery_controller.py
+++ b/custom_components/foxess_em/battery/battery_controller.py
@@ -5,6 +5,7 @@ import logging
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.event import async_track_state_change_event
+from typing import Any
 
 from custom_components.foxess_em.battery.battery_util import BatteryUtils
 from custom_components.foxess_em.battery.schedule import Schedule
@@ -74,11 +75,11 @@ class BatteryController(UnloadController, CallbackController, HassLoadController
         """Model status"""
         return self._model.ready()
 
-    async def async_refresh(self, *args) -> None:
+    async def async_refresh(self, *_: Any) -> None:
         """Async refresh"""
         self.refresh()
 
-    def refresh(self, *args) -> None:  # pylint: disable=unused-argument
+    def refresh(self, *_: Any) -> None:
         """Refresh battery model"""
         _LOGGER.debug("Refreshing battery model")
 

--- a/custom_components/foxess_em/charge/charge_service.py
+++ b/custom_components/foxess_em/charge/charge_service.py
@@ -9,6 +9,7 @@ from homeassistant.helpers.event import (
     async_track_state_change,
     async_track_utc_time_change,
 )
+from typing import Any
 
 from custom_components.foxess_em.fox.fox_service import FoxService
 from custom_components.foxess_em.util.peak_period_util import PeakPeriodUtils
@@ -98,7 +99,7 @@ class ChargeService(UnloadController):
         )
         self._unload_listeners.append(eco_end)
 
-    async def _eco_start_setup(self, *args) -> None:  # pylint: disable=unused-argument
+    async def _eco_start_setup(self, *_: Any) -> None:
         """Set target SoC"""
 
         _LOGGER.debug("Calculating optimal battery SoC")
@@ -123,7 +124,7 @@ class ChargeService(UnloadController):
         _LOGGER.debug("Charge rate set to %dA for %s", self._target_charge_amps, window)
         await self._fox.set_charge_current(self._target_charge_amps)
 
-    async def _eco_start(self, *args) -> None:  # pylint: disable=unused-argument
+    async def _eco_start(self, *_: Any) -> None:
         """Eco start"""
 
         _LOGGER.debug("Setting min SoC to %d%%", self._perc_target)
@@ -138,20 +139,20 @@ class ChargeService(UnloadController):
             await self._stop_force_charge()
 
     async def _start_force_charge_off_peak(
-        self, *args
-    ) -> None:  # pylint: disable=unused-argument
+        self, *_: Any
+    ) -> None:
         """Set Fox force charge settings to True"""
         self._charge_active = True
         await self._fox.start_force_charge_off_peak()
 
     async def _stop_force_charge(
-        self, *args
-    ) -> None:  # pylint: disable=unused-argument
+        self, *_: Any
+    ) -> None:
         """Set Fox force charge settings to False"""
         self._charge_active = False
         await self._fox.stop_force_charge()
 
-    async def _eco_end(self, *args) -> None:  # pylint: disable=unused-argument
+    async def _eco_end(self, *_: Any) -> None:
         """Stop holding SoC"""
 
         self._stop_listening()
@@ -165,7 +166,7 @@ class ChargeService(UnloadController):
 
     async def _battery_soc_change(
         self, entity, old_state, new_state
-    ):  # pylint: disable=unused-argument
+    ) -> None:
         new_state = float(new_state.state)
 
         if self._custom_charge_profile and new_state > 90:

--- a/custom_components/foxess_em/common/switch.py
+++ b/custom_components/foxess_em/common/switch.py
@@ -7,6 +7,7 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_IDENTIFIERS, ATTR_NAME
 from homeassistant.helpers.device_registry import DeviceEntryType
+from typing import Any
 
 from ..common.switch_desc import SwitchDescription
 from ..const import ATTR_ENTRY_TYPE, DEFAULT_NAME, DOMAIN, SWITCH
@@ -32,12 +33,12 @@ class Switch(SwitchEntity, RestoreEntity):
 
         self._unique_id = f"{DEFAULT_NAME}_{SWITCH}_{self.switch_desc.name}"
 
-    async def async_turn_on(self, **kwargs) -> None:  # pylint: disable=unused-argument
+    async def async_turn_on(self, **_: Any) -> None:
         """Turn on the switch."""
         switch = getattr(self._controller, self.switch_desc.switch)
         switch(True)
 
-    async def async_turn_off(self, **kwargs) -> None:  # pylint: disable=unused-argument
+    async def async_turn_off(self, **_: Any) -> None:
         """Turn off the switch."""
         switch = getattr(self._controller, self.switch_desc.switch)
         switch(False)

--- a/custom_components/foxess_em/forecast/forecast_controller.py
+++ b/custom_components/foxess_em/forecast/forecast_controller.py
@@ -6,6 +6,7 @@ import logging
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.event import async_track_utc_time_change
 from pandas import DataFrame
+from typing import Any
 
 from custom_components.foxess_em.common.hass_load_controller import HassLoadController
 from custom_components.foxess_em.const import FORECAST
@@ -147,7 +148,7 @@ class ForecastController(UnloadController, CallbackController, HassLoadControlle
         """Model status"""
         return self._api.ready()
 
-    async def async_refresh(self, *args) -> None:  # pylint: disable=unused-argument
+    async def async_refresh(self, *_: Any) -> None:
         """Refresh forecast"""
         try:
             _LOGGER.debug("Refreshing forecast data")
@@ -165,8 +166,8 @@ class ForecastController(UnloadController, CallbackController, HassLoadControlle
         self._notify_listeners()
 
     async def _async_get_site_info(
-        self, *args
-    ) -> None:  # pylint: disable=unused-argument
+        self, *_: Any
+    ) -> None:
         """Refresh site info"""
         try:
             _LOGGER.debug("Setting Solcast site info")
@@ -188,7 +189,7 @@ class ForecastController(UnloadController, CallbackController, HassLoadControlle
         """Return resampled data"""
         return self._api.raw_data()
 
-    async def _reset_api_count(self, *args) -> None:  # pylint: disable=unused-argument
+    async def _reset_api_count(self, *_: Any) -> None:
         """Reset API count to 0"""
         self._api_count = 0
 

--- a/custom_components/foxess_em/fox/fox_cloud_service.py
+++ b/custom_components/foxess_em/fox/fox_cloud_service.py
@@ -4,6 +4,7 @@ from datetime import datetime, time
 import logging
 
 from homeassistant.core import HomeAssistant
+from typing import Any
 
 from ..util.exceptions import NoDataError
 from .fox_cloud_api import FoxCloudApiClient
@@ -77,7 +78,7 @@ class FoxCloudService(FoxService):
         except NoDataError as ex:
             _LOGGER.error(ex)
 
-    async def stop_force_charge(self, *args) -> None:  # pylint: disable=unused-argument
+    async def stop_force_charge(self, *_: Any) -> None:
         """Start force charge"""
         _LOGGER.debug("Requesting stop force charge from Fox Cloud")
 
@@ -92,8 +93,8 @@ class FoxCloudService(FoxService):
             _LOGGER.error(ex)
 
     async def set_min_soc(
-        self, soc: int, *args
-    ) -> None:  # pylint: disable=unused-argument
+        self, soc: int, *_: Any
+    ) -> None:
         """Start force charge"""
         _LOGGER.debug("Sending min SoC to Fox Cloud")
 
@@ -106,7 +107,7 @@ class FoxCloudService(FoxService):
         except NoDataError as ex:
             _LOGGER.error(ex)
 
-    async def set_charge_current(self, charge_current: float, *args) -> None:
+    async def set_charge_current(self, charge_current: float, *_: Any) -> None:
         """Set charge current"""
         _LOGGER.debug(
             "Skipping call to set charge current as not supported using the Cloud"

--- a/custom_components/foxess_em/fox/fox_modbus_service.py
+++ b/custom_components/foxess_em/fox/fox_modbus_service.py
@@ -4,6 +4,7 @@ from datetime import datetime, time
 import logging
 
 from homeassistant.core import HomeAssistant
+from typing import Any
 
 from .fox_modbus import FoxModbus
 from .fox_service import FoxService
@@ -68,19 +69,19 @@ class FoxModbuservice(FoxService):
                 _P1_ENABLE, [1, start_encoded, stop_encoded, 0, 0, 0], self._slave
             )
 
-    async def stop_force_charge(self, *args) -> None:  # pylint: disable=unused-argument
+    async def stop_force_charge(self, *_: Any) -> None:
         """Start force charge"""
         _LOGGER.debug("Requesting stop force charge from Fox Modbus")
         await self._modbus.write_registers(_P1_ENABLE, [0, 0, 0, 0, 0, 0], self._slave)
 
     async def set_min_soc(
-        self, soc: int, *args
-    ) -> None:  # pylint: disable=unused-argument
+        self, soc: int, *_: Any
+    ) -> None:
         """Start force charge"""
         _LOGGER.debug("Request set min SoC to Fox Modbus")
         await self._modbus.write_registers(_MIN_SOC, [soc], self._slave)
 
-    async def set_charge_current(self, charge_current: float, *args) -> None:
+    async def set_charge_current(self, charge_current: float, *_: Any) -> None:
         """Set charge current"""
         _LOGGER.debug(
             f"Requesting set charge current of {charge_current}A to Fox Modbus"

--- a/custom_components/foxess_em/fox/fox_service.py
+++ b/custom_components/foxess_em/fox/fox_service.py
@@ -1,6 +1,7 @@
 """Fox controller"""
 
 import logging
+from typing import Any
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -8,25 +9,25 @@ _LOGGER = logging.getLogger(__name__)
 class FoxService:
     """Fox service"""
 
-    async def start_force_charge_now(self, *args) -> None:
+    async def start_force_charge_now(self, *_: Any) -> None:
         """Start force charge now"""
         pass
 
-    async def start_force_charge_off_peak(self, *args) -> None:
+    async def start_force_charge_off_peak(self, *_: Any) -> None:
         """Start force charge off peak"""
         pass
 
-    async def stop_force_charge(self, *args) -> None:  # pylint: disable=unused-argument
+    async def stop_force_charge(self, *_: Any) -> None:
         """Start force charge"""
         pass
 
     async def set_min_soc(
-        self, soc: int, *args
-    ) -> None:  # pylint: disable=unused-argument
+        self, soc: int, *_: Any
+    ) -> None:
         """Set Min SoC"""
         pass
 
-    async def set_charge_current(self, charge_current: float, *args) -> None:
+    async def set_charge_current(self, charge_current: float, *_: Any) -> None:
         """Set charge current"""
         pass
 


### PR DESCRIPTION
## Summary
- clean up unused argument `pylint` overrides
- type hint extraneous callback args with `Any`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6840700e6ce883338de0762f9396f77d